### PR TITLE
Asset file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `file:path` to indicate a relative path for the asset file.
+- `file:rel_path` to indicate a relative path for the asset file.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `file:path` to indicate a relative path for the asset file.
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `file:rel_path` to indicate a relative path for the asset file.
+- `file:local_path` to indicate a relative path for the asset file.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following fields can be used for assets (in the [`Asset Object`](https://git
 | file:header_size     | integer                                 | The header [size](#sizes) of the file, specified in bytes.   |
 | file:size            | integer                                 | The file [size](#sizes), specified in bytes.                 |
 | file:values          | \[[Mapping Object](#mapping-object)\]   | Lists the value that are in the file and describes their meaning. See the [Mapping Object](#mapping-object) chapter for an example. If given, at least one array element is required. |
-| file:path            | string                                  | [File path](#file-path) of the asset                 |
+| file:rel_path        | string                                  | [Relative path](#relative-path) of the asset                 |
 
 **Note:** File specific details should not be part of the Item Assets Definition extension to Collections.
 
@@ -83,12 +83,12 @@ file with file content `test`.
 - Algorithm `sha2` (256 bits truncated to 160 bits): `12149f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b`
 - Algorithm `blake2b-128`: `90e4021044a8995dd50b6657a037a7839304535b`
 
-### File path
+### Relative Path
 
 An asset is referenced with a simple URL that do not give any indication about how the asset file might be organized if downloaded in a file system.
 Some software requires that the asset is placed in a specific relative folder or the metadata asset might references relative path to another asset.
-The `file:path` field indicates a path (relative is recommended) within the "download" directory in order
-for the downloading agent to organize it as expected.
+The `file:rel_path` field indicates a relative path is recommended) within the "download" directory in order for the downloading agent
+to organize it as expected.
 This information is similar to the [`Content-Disposition` header](https://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1) in HTTP protocol.
 
 For instance, [SNAP toolbox](https://step.esa.int/main/) reads the SAFE manifest to open a product that references the different files

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following fields can be used for assets (in the [`Asset Object`](https://git
 | file:header_size     | integer                                 | The header [size](#sizes) of the file, specified in bytes.   |
 | file:size            | integer                                 | The file [size](#sizes), specified in bytes.                 |
 | file:values          | \[[Mapping Object](#mapping-object)\]   | Lists the value that are in the file and describes their meaning. See the [Mapping Object](#mapping-object) chapter for an example. If given, at least one array element is required. |
-| file:rel_path        | string                                  | [Relative path](#relative-path) of the asset                 |
+| file:local_path      | string                                  | The file [Local path](#local-path) of the asset (must be relative) |
 
 **Note:** File specific details should not be part of the Item Assets Definition extension to Collections.
 
@@ -83,11 +83,11 @@ file with file content `test`.
 - Algorithm `sha2` (256 bits truncated to 160 bits): `12149f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b`
 - Algorithm `blake2b-128`: `90e4021044a8995dd50b6657a037a7839304535b`
 
-### Relative Path
+### Local Path
 
 An asset is referenced with a simple URL that do not give any indication about how the asset file might be organized if downloaded in a file system.
 Some software requires that the asset is placed in a specific relative folder or the metadata asset might references relative path to another asset.
-The `file:rel_path` field indicates a relative path is recommended) within the "download" directory in order for the downloading agent
+The `file:local_path` field indicates a **relative** path from the "download" directory in order for the downloading agent
 to organize it as expected.
 This information is similar to the [`Content-Disposition` header](https://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1) in HTTP protocol.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following fields can be used for assets (in the [`Asset Object`](https://git
 | file:header_size     | integer                                 | The header [size](#sizes) of the file, specified in bytes.   |
 | file:size            | integer                                 | The file [size](#sizes), specified in bytes.                 |
 | file:values          | \[[Mapping Object](#mapping-object)\]   | Lists the value that are in the file and describes their meaning. See the [Mapping Object](#mapping-object) chapter for an example. If given, at least one array element is required. |
-| file:path            | string                                  | [Relative path](#relative-path) of the asset                 |
+| file:path            | string                                  | [File path](#file-path) of the asset                 |
 
 **Note:** File specific details should not be part of the Item Assets Definition extension to Collections.
 
@@ -83,11 +83,11 @@ file with file content `test`.
 - Algorithm `sha2` (256 bits truncated to 160 bits): `12149f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b`
 - Algorithm `blake2b-128`: `90e4021044a8995dd50b6657a037a7839304535b`
 
-### Relative path
+### File path
 
 An asset is referenced with a simple URL that do not give any indication about how the asset file might be organized if downloaded in a file system.
 Some software requires that the asset is placed in a specific relative folder or the metadata asset might references relative path to another asset.
-The `file:path` field indicates a relative path within the "download" directory in order for the receiving agent to organize it as expected.
+The `file:path` field indicates a path (recommended as relative) within the "download" directory in order for the downloading agent to organize it as expected.
 This information is similar to the [`Content-Disposition` header](https://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1) in HTTP protocol.
 
 For instance, [SNAP toolbox](https://step.esa.int/main/) reads the SAFE manifest to open a product that references the different files

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ file with file content `test`.
 
 An asset is referenced with a simple URL that do not give any indication about how the asset file might be organized if downloaded in a file system.
 Some software requires that the asset is placed in a specific relative folder or the metadata asset might references relative path to another asset.
-The `file:path` field indicates a path (recommended as relative) within the "download" directory in order for the downloading agent to organize it as expected.
+The `file:path` field indicates a path (relative is recommended) within the "download" directory in order
+for the downloading agent to organize it as expected.
 This information is similar to the [`Content-Disposition` header](https://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1) in HTTP protocol.
 
 For instance, [SNAP toolbox](https://step.esa.int/main/) reads the SAFE manifest to open a product that references the different files
@@ -103,10 +104,10 @@ for running tests are copied here for convenience.
 
 ### Running tests
 
-The same checks that run as checks on PR's are part of the repository and can be run locally to verify that changes are valid. 
+The same checks that run as checks on PR's are part of the repository and can be run locally to verify that changes are valid.
 To run tests locally, you'll need `npm`, which is a standard part of any [node.js installation](https://nodejs.org/en/download/).
 
-First you'll need to install everything with npm once. Just navigate to the root of this repository and on 
+First you'll need to install everything with npm once. Just navigate to the root of this repository and on
 your command line run:
 ```bash
 npm install

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The following fields can be used for assets (in the [`Asset Object`](https://git
 | file:header_size     | integer                                 | The header [size](#sizes) of the file, specified in bytes.   |
 | file:size            | integer                                 | The file [size](#sizes), specified in bytes.                 |
 | file:values          | \[[Mapping Object](#mapping-object)\]   | Lists the value that are in the file and describes their meaning. See the [Mapping Object](#mapping-object) chapter for an example. If given, at least one array element is required. |
+| file:path            | string                                  | [Relative path](#relative-path) of the asset                 |
 
 **Note:** File specific details should not be part of the Item Assets Definition extension to Collections.
 
@@ -81,6 +82,16 @@ file with file content `test`.
 - Algorithm `sha2` (256 bits): `12209f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08`
 - Algorithm `sha2` (256 bits truncated to 160 bits): `12149f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b`
 - Algorithm `blake2b-128`: `90e4021044a8995dd50b6657a037a7839304535b`
+
+### Relative path
+
+An asset is referenced with a simple URL that do not give any indication about how the asset file might be organized if downloaded in a file system.
+Some software requires that the asset is placed in a specific relative folder or the metadata asset might references relative path to another asset.
+The `file:path` field indicates a relative path within the "download" directory in order for the receiving agent to organize it as expected.
+This information is similar to the [`Content-Disposition` header](https://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1) in HTTP protocol.
+
+For instance, [SNAP toolbox](https://step.esa.int/main/) reads the SAFE manifest to open a product that references the different files
+(e.g. image bands) relatively and thus expects to find them in the referenced folder (e.g. IMG_DATA).
 
 ## Contributing
 

--- a/examples/item.json
+++ b/examples/item.json
@@ -46,13 +46,15 @@
       "href": "./annotation/calibration/noise-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml",
       "title": "Calibration Schema",
       "type": "text/xml",
-      "file:checksum": "90e40210a30d1711e81a4b11ef67b28744321659"
+      "file:checksum": "90e40210a30d1711e81a4b11ef67b28744321659",
+      "file:path": "S1A_EW_GRDM_1SSH_20181103T235855_20181103T235955_024430_02AD5D_5616.SAFE/annotation/calibration/noise-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml"
     },
     "calibrations": {
       "href": "./annotation/calibration/calibration-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml",
       "title": "Noise Schema",
       "type": "text/xml",
-      "file:checksum": "90e402104fc5351af67db0b8f1746efe421a05e4"
+      "file:checksum": "90e402104fc5351af67db0b8f1746efe421a05e4",
+      "file:path": "S1A_EW_GRDM_1SSH_20181103T235855_20181103T235955_024430_02AD5D_5616.SAFE/annotation/calibration/calibration-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml"
     },
     "products": {
       "href": "./annotation/s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml",

--- a/examples/item.json
+++ b/examples/item.json
@@ -47,14 +47,14 @@
       "title": "Calibration Schema",
       "type": "text/xml",
       "file:checksum": "90e40210a30d1711e81a4b11ef67b28744321659",
-      "file:path": "S1A_EW_GRDM_1SSH_20181103T235855_20181103T235955_024430_02AD5D_5616.SAFE/annotation/calibration/noise-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml"
+      "file:rel_path": "S1A_EW_GRDM_1SSH_20181103T235855_20181103T235955_024430_02AD5D_5616.SAFE/annotation/calibration/noise-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml"
     },
     "calibrations": {
       "href": "./annotation/calibration/calibration-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml",
       "title": "Noise Schema",
       "type": "text/xml",
       "file:checksum": "90e402104fc5351af67db0b8f1746efe421a05e4",
-      "file:path": "S1A_EW_GRDM_1SSH_20181103T235855_20181103T235955_024430_02AD5D_5616.SAFE/annotation/calibration/calibration-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml"
+      "file:rel_path": "S1A_EW_GRDM_1SSH_20181103T235855_20181103T235955_024430_02AD5D_5616.SAFE/annotation/calibration/calibration-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml"
     },
     "products": {
       "href": "./annotation/s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml",

--- a/examples/item.json
+++ b/examples/item.json
@@ -47,14 +47,14 @@
       "title": "Calibration Schema",
       "type": "text/xml",
       "file:checksum": "90e40210a30d1711e81a4b11ef67b28744321659",
-      "file:rel_path": "S1A_EW_GRDM_1SSH_20181103T235855_20181103T235955_024430_02AD5D_5616.SAFE/annotation/calibration/noise-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml"
+      "file:local_path": "S1A_EW_GRDM_1SSH_20181103T235855_20181103T235955_024430_02AD5D_5616.SAFE/annotation/calibration/noise-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml"
     },
     "calibrations": {
       "href": "./annotation/calibration/calibration-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml",
       "title": "Noise Schema",
       "type": "text/xml",
       "file:checksum": "90e402104fc5351af67db0b8f1746efe421a05e4",
-      "file:rel_path": "S1A_EW_GRDM_1SSH_20181103T235855_20181103T235955_024430_02AD5D_5616.SAFE/annotation/calibration/calibration-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml"
+      "file:local_path": "S1A_EW_GRDM_1SSH_20181103T235855_20181103T235955_024430_02AD5D_5616.SAFE/annotation/calibration/calibration-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml"
     },
     "products": {
       "href": "./annotation/s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml",

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -128,7 +128,7 @@
             }
           }
         },
-        "file:path": {
+        "file:rel_path": {
           "type": "string",
           "pattern": "^(?!-)[^\/]+(?<!-)(\/(?!-)[^\/]+(?<!-))*$",
           "title": "Relative File Path"

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -127,6 +127,11 @@
               }
             }
           }
+        },
+        "file:path": {
+          "type": "string",
+          "pattern": "^(?!-)[^\/]+(?<!-)(\/(?!-)[^\/]+(?<!-))*$",
+          "title": "Relative File Path"
         }
       },
       "patternProperties": {

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -128,7 +128,7 @@
             }
           }
         },
-        "file:rel_path": {
+        "file:local_path": {
           "type": "string",
           "pattern": "^(?!-)[^\/]+(?<!-)(\/(?!-)[^\/]+(?<!-))*$",
           "title": "Relative File Path"


### PR DESCRIPTION
## Context

When downloading assets locally to run some software (e.g. ESA SNAP on S2), it expects the file organized as originally in the SAFE manifest. Assets may be distributed in the cloud and have lost this organizational information in its own url.

## Proposed Solution

- `file:path` field to indicate a relative path that may be used to organize files as expected.