### PR TITLE
Update maturity level #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - **Identifier:** <https://stac-extensions.github.io/file/v2.1.0/schema.json>
 - **Field Name Prefix:** file
 - **Scope:** Item, Catalog, Collection
-- **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Candidate
+- **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Stable
 - **Owner**: @m-mohr
 - **History**: [Prior to March 2nd 2021](https://github.com/radiantearth/stac-spec/commits/4a841605ad83a16f45fcb88ed90117d6c77a7f04/extensions/file)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - **Identifier:** <https://stac-extensions.github.io/file/v2.1.0/schema.json>
 - **Field Name Prefix:** file
 - **Scope:** Item, Catalog, Collection
-- **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Proposal
+- **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Candidate
 - **Owner**: @m-mohr
 - **History**: [Prior to March 2nd 2021](https://github.com/radiantearth/stac-spec/commits/4a841605ad83a16f45fcb88ed90117d6c77a7f04/extensions/file)
 


### PR DESCRIPTION
Update the maturity level to Candidate following the STAC Maturity table.

Reason: 6+ implementations: 2 implementations of 2.x from crawl, CARD4L uses it (+3 implementations), 2 private implementations, no changes anticipated

Fixes #13